### PR TITLE
Fallback for hex codes that dont match any name

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,7 +15,9 @@ Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.3
 Suggests:
     testthat (>= 3.0.0),
-    gt
+    gt,
+    farver,
+    cli
 Config/testthat/edition: 3
 Depends:
     R (>= 3.5.0)

--- a/R/fallback_nearest_hex.R
+++ b/R/fallback_nearest_hex.R
@@ -1,0 +1,55 @@
+# Find the nearest named color for a given hex code using Lab distance
+
+# If this function is accepted, the following should be implemnted:
+  # {fraver} added as a suggestion namespace
+  # color_table should be pre-computed with Lab values - and remove computation from inside the function
+    # Optional: compute other metrices as well (checkout farver for more details, OKLab, ΔE2000..)
+    # Optional: allow fallback to R-specific color names, rather than the full color table
+  # Add optional argument to `hex_to_color`, either named or not (fallback/...). it will be passed to other color-spacing functions, such as hsl, oklab..
+    
+
+
+fallback_nearest_hex <- function(hex, color_table = get_color_data()) {
+  if (!requireNamespace("farver", quietly = TRUE)) {
+    stop(
+      "Package 'farver' is required for fallback_nearest_hex(). ",
+      "Install it with: install.packages('farver')",
+      call. = FALSE
+    )
+  }
+
+  if (!is.character(hex)) {
+    stop("hex must be a character vector of hex codes")
+  }
+
+  # i mean, ill leave it. but this is kinda verbose...
+  if (!is.data.frame(color_table) || !all(c("name", "hex") %in% names(color_table))) {
+    stop("color_table must be a data frame with columns 'name' and 'hex'")
+  }
+
+  if (any(is.na(hex))) {
+    stop("hex cannot contain NA values")
+  }
+
+  # Convert hex codes to Lab
+  hex_lab <- farver::decode_colour(hex, to = "lab")
+
+  # Convert reference colors to Lab 
+      # TODO: // THIS SHOULD DEFINETLY BE PRE-COMPUTED in color_table
+  ref_lab <- farver::decode_colour(color_table$hex, to = "lab")
+
+  nearest <- vapply(
+    seq_len(nrow(hex_lab)),
+    function(i) {
+      distances <- sqrt(
+        (hex_lab[i, 1] - ref_lab[, 1])^2 +
+          (hex_lab[i, 2] - ref_lab[, 2])^2 +
+          (hex_lab[i, 3] - ref_lab[, 3])^2
+      )
+      color_table$name[which.min(distances)]
+    },
+    character(1)
+  )
+
+  unname(nearest)
+}

--- a/R/oklab_conversion.R
+++ b/R/oklab_conversion.R
@@ -1,0 +1,83 @@
+# Convert color inputs to OKLab
+# Uses the existing color name database (base R + extended) via color_to_hex()
+
+hex_to_oklab <- function(hex) {
+  if (!is.character(hex)) {
+    stop("Input must be a character vector of hex codes")
+  }
+
+  if (any(is.na(hex))) {
+    stop("NA values are not allowed in hex codes")
+  }
+
+  hex_pattern <- "^#[0-9A-Fa-f]{6}([0-9A-Fa-f]{2})?$"
+  if (!all(grepl(hex_pattern, hex))) {
+    invalid <- hex[!grepl(hex_pattern, hex)]
+    stop(
+      "Invalid hex code format. Expected format: #RRGGBB or #RRGGBBAA. Invalid values: ",
+      paste(invalid, collapse = ", ")
+    )
+  }
+
+  hex_std <- toupper(hex)
+  alpha <- rep(1, length(hex_std))
+
+  is8 <- nchar(hex_std) == 9
+  if (any(is8)) {
+    alpha[is8] <- strtoi(substr(hex_std[is8], 8, 9), 16L) / 255
+    hex_std[is8] <- substr(hex_std[is8], 1, 7)
+  }
+
+  r <- strtoi(substr(hex_std, 2, 3), 16L) / 255
+  g <- strtoi(substr(hex_std, 4, 5), 16L) / 255
+  b <- strtoi(substr(hex_std, 6, 7), 16L) / 255
+
+  to_linear <- function(x) ifelse(x <= 0.04045, x / 12.92, ((x + 0.055) / 1.055) ^ 2.4)
+  r_lin <- to_linear(r)
+  g_lin <- to_linear(g)
+  b_lin <- to_linear(b)
+
+  rgb_lin <- rbind(r_lin, g_lin, b_lin)
+
+  m1 <- matrix(
+    c(
+      0.4122214708, 0.5363325363, 0.0514459929,
+      0.2119034982, 0.6806995451, 0.1073969566,
+      0.0883024619, 0.2817188376, 0.6299787005
+    ),
+    nrow = 3,
+    byrow = TRUE
+  )
+
+  m2 <- matrix(
+    c(
+      0.2104542553, 0.7936177850, -0.0040720468,
+      1.9779984951, -2.4285922050, 0.4505937099,
+      0.0259040371, 0.7827717662, -0.8086757660
+    ),
+    nrow = 3,
+    byrow = TRUE
+  )
+
+  lms <- m1 %*% rgb_lin
+  lms_cbrt <- lms ^ (1 / 3)
+  lab <- m2 %*% lms_cbrt
+
+  data.frame(
+    L = lab[1, ],
+    a = lab[2, ],
+    b = lab[3, ],
+    alpha = alpha,
+    stringsAsFactors = FALSE,
+    row.names = NULL
+  )
+}
+
+color_to_oklab <- function(color) {
+  if (!is.character(color)) {
+    stop("Input must be a character vector of color names")
+  }
+
+  hex_codes <- color_to_hex(color)
+  hex_to_oklab(hex_codes)
+}

--- a/R/oklab_inverse.R
+++ b/R/oklab_inverse.R
@@ -1,0 +1,56 @@
+# Convert OKLab to hex and color names
+
+oklab_to_hex <- function(L, a, b, alpha = 1) {
+  if (!is.numeric(L) || !is.numeric(a) || !is.numeric(b)) {
+    stop("Inputs L, a, and b must be numeric")
+  }
+  if (!is.numeric(alpha)) {
+    stop("Alpha must be numeric")
+  }
+
+  n <- length(L)
+  if (!(length(a) == n && length(b) == n && (length(alpha) == 1 || length(alpha) == n))) {
+    stop("L, a, b, and alpha must have compatible lengths")
+  }
+
+  L_vals <- as.numeric(L)
+  a_vals <- as.numeric(a)
+  b_vals <- as.numeric(b)
+  alpha_vals <- if (length(alpha) == 1) rep(alpha, n) else as.numeric(alpha)
+
+  if (any(is.na(L_vals) | is.na(a_vals) | is.na(b_vals) | is.na(alpha_vals))) {
+    stop("Inputs cannot contain NA")
+  }
+
+  l_ <- (L_vals + 0.3963377774 * a_vals + 0.2158037573 * b_vals) ^ 3
+  m_ <- (L_vals - 0.1055613458 * a_vals - 0.0638541728 * b_vals) ^ 3
+  s_ <- (L_vals - 0.0894841775 * a_vals - 1.2914855480 * b_vals) ^ 3
+
+  r_lin <- 4.0767416621 * l_ - 3.3077115913 * m_ + 0.2309699292 * s_
+  g_lin <- -1.2684380046 * l_ + 2.6097574011 * m_ - 0.3413193965 * s_
+  b_lin <- -0.0041960863 * l_ - 0.7034186147 * m_ + 1.7076147010 * s_
+
+  clamp01 <- function(x) pmin(pmax(x, 0), 1)
+  r_lin <- clamp01(r_lin)
+  g_lin <- clamp01(g_lin)
+  b_lin <- clamp01(b_lin)
+
+  to_srgb <- function(x) ifelse(x <= 0.0031308, 12.92 * x, 1.055 * (x ^ (1 / 2.4)) - 0.055)
+  r <- to_srgb(r_lin)
+  g <- to_srgb(g_lin)
+  b <- to_srgb(b_lin)
+
+  channel_hex <- function(x) sprintf("%02X", round(clamp01(x) * 255))
+  rgb_hex <- paste0("#", channel_hex(r), channel_hex(g), channel_hex(b))
+
+  alpha_hex <- channel_hex(clamp01(alpha_vals))
+  use_alpha <- alpha_vals != 1
+  rgb_hex[use_alpha] <- paste0(rgb_hex[use_alpha], alpha_hex[use_alpha])
+
+  rgb_hex
+}
+
+oklab_to_color <- function(L, a, b, alpha = 1) {
+  hex_codes <- oklab_to_hex(L, a, b, alpha)
+  hex_to_color(hex_codes)
+}

--- a/man/hex_to_color.Rd
+++ b/man/hex_to_color.Rd
@@ -4,7 +4,7 @@
 \alias{hex_to_color}
 \title{Convert Hex Codes to Color Names}
 \usage{
-hex_to_color(hex)
+hex_to_color(hex, fallback_nearest_color = TRUE, fallback_distance = c("lab"))
 }
 \arguments{
 \item{hex}{A character vector of hexadecimal color codes in the format "#RRGGBB"

--- a/tests/testthat/test-fallback_nearest_hex.R
+++ b/tests/testthat/test-fallback_nearest_hex.R
@@ -1,0 +1,17 @@
+test_that("hex_to_color falls back to nearest when no exact match", {
+  skip_if_not_installed("farver")
+
+  table_hex <- get_color_data()$hex
+  candidate <- "#123456"
+  if (candidate %in% table_hex) {
+    pool <- sprintf("#%06X", sample.int(16^6, 10) - 1)
+    candidate <- setdiff(pool, table_hex)[1]
+  }
+
+  expect_warning({
+    res <- hex_to_color(candidate, fallback_nearest_color = TRUE)
+    expect_type(res, "character")
+    expect_false(is.na(res))
+    expect_length(res, 1)
+  }, "falling back")
+})

--- a/tests/testthat/test-get_color_data.R
+++ b/tests/testthat/test-get_color_data.R
@@ -5,7 +5,10 @@ test_that("get_color_data returns a data frame", {
 
 test_that("get_color_data has correct columns", {
   result <- get_color_data()
-  expect_named(result, c("name", "hex"))
+  expect_true(all(c("name", "hex") %in% names(result)))
+  if (requireNamespace("farver", quietly = TRUE)) {
+    expect_true(all(c("lab_l", "lab_a", "lab_b") %in% names(result)))
+  }
   expect_type(result$name, "character")
   expect_type(result$hex, "character")
 })

--- a/tests/testthat/test-oklab_conversion.R
+++ b/tests/testthat/test-oklab_conversion.R
@@ -1,0 +1,17 @@
+test_that("hex_to_oklab returns expected values for red", {
+  result <- col2hex2col:::hex_to_oklab("#FF0000")
+
+  expect_equal(result$L, 0.6279554, tolerance = 1e-6)
+  expect_equal(result$a, 0.2248631, tolerance = 1e-6)
+  expect_equal(result$b, 0.1258463, tolerance = 1e-6)
+  expect_equal(result$alpha, 1)
+})
+
+test_that("color_to_oklab returns expected values for red", {
+  result <- col2hex2col:::color_to_oklab("red")
+
+  expect_equal(result$L, 0.6279554, tolerance = 1e-6)
+  expect_equal(result$a, 0.2248631, tolerance = 1e-6)
+  expect_equal(result$b, 0.1258463, tolerance = 1e-6)
+  expect_equal(result$alpha, 1)
+})

--- a/tests/testthat/test-oklab_inverse.R
+++ b/tests/testthat/test-oklab_inverse.R
@@ -1,0 +1,9 @@
+test_that("oklab_to_hex converts red correctly", {
+  hex <- col2hex2col:::oklab_to_hex(0.6279554, 0.2248631, 0.1258463)
+  expect_equal(hex, "#FF0000")
+})
+
+test_that("oklab_to_color converts red correctly", {
+  color <- col2hex2col:::oklab_to_color(0.6279554, 0.2248631, 0.1258463)
+  expect_equal(color, "red")
+})


### PR DESCRIPTION
Not all hex codes have a matching name. This function gracefully returns the nearest color name by computing the LAB distance (from the [{farver}](https://github.com/thomasp85/farver) package) and return the closest match.

If this function is accepted, the following should be considered:
- [{farver}](https://github.com/thomasp85/farver) added as a suggestion namespace
- color_table should be pre-computed with Lab values - and remove computation from inside the function
    - Optional: compute other metrices as well (checkout farver for more details, OKLab, ΔE2000..)
    - Optional: allow fallback to R-specific color names, rather than the full color table
- Add optional argument to [`hex_to_color`](https://github.com/AnttiRask/col2hex2col/blob/main/R/color_conversion.R), either named or not (`fallback`/`...`). it will be passed to other color-spacing functions, such as hsl, oklab if name returns NA
- [color_conversion.R](https://github.com/AnttiRask/col2hex2col/blob/main/R/color_conversion.R) should probably renamed to something more specific that clarifies that this is a HEX - Color function
    